### PR TITLE
Fix a bug where the previous gem does not exist

### DIFF
--- a/lib/tachikoma_ai/strategies/bundler.rb
+++ b/lib/tachikoma_ai/strategies/bundler.rb
@@ -24,8 +24,8 @@ module TachikomaAi
         previous = lockfile('HEAD^')
         @updated_gems = diff_specs(previous, lockfile('HEAD')).map do |spec|
           before = previous.specs.find { |s| s.name == spec.name }
-          Gem.new(spec.name, before.version.to_s, spec.version.to_s)
-        end.uniq(&:name)
+          gem(spec, before)
+        end.compact.uniq(&:name)
       end
 
       def diff_specs(previous, current)
@@ -42,6 +42,11 @@ module TachikomaAi
 
       def homepage_urls
         updated_gems.reject(&:github_url?).map(&:homepage).join("\n")
+      end
+
+      def gem(spec, before)
+        return if before.nil?
+        Gem.new(spec.name, before.version.to_s, spec.version.to_s)
       end
     end
   end

--- a/spec/tachikoma_ai/strategies/bundler_spec.rb
+++ b/spec/tachikoma_ai/strategies/bundler_spec.rb
@@ -5,9 +5,6 @@ module TachikomaAi
     describe Bundler do
       describe '#pull_request_body' do
         let(:bundler) { Bundler.new }
-        let(:expected) { 'https://github.com/sinsoku/tachikoma_ai/compare/v0.1.0...v0.2.0' }
-        let(:previous) { ::Bundler::LockfileParser.new("GEM\n  specs:\n    tachikoma_ai (0.1.0)") }
-        let(:current) { ::Bundler::LockfileParser.new("GEM\n  specs:\n    tachikoma_ai (0.2.0)") }
 
         before do
           allow(bundler).to receive(:lockfile).and_return(previous, current)
@@ -15,7 +12,31 @@ module TachikomaAi
           stub_request(:get, 'https://api.github.com/repos/sinsoku/tachikoma_ai/git/refs/tags')
             .to_return(status: 200, body: '[{"ref":"refs/tags/v0.1.0"}, {"ref":"refs/tags/v0.2.0"}]')
         end
-        it { expect(bundler.pull_request_body).to include expected }
+
+        context 'when successful' do
+          let(:expected) { 'https://github.com/sinsoku/tachikoma_ai/compare/v0.1.0...v0.2.0' }
+
+          let(:previous) { ::Bundler::LockfileParser.new("GEM\n  specs:\n    tachikoma_ai (0.1.0)") }
+          let(:current) { ::Bundler::LockfileParser.new("GEM\n  specs:\n    tachikoma_ai (0.2.0)") }
+
+          it { expect(bundler.pull_request_body).to include expected }
+        end
+
+        context 'when unsuccessful' do
+          let(:expected) { 'activesupport' }
+          let(:previous) do
+            ::Bundler::LockfileParser.new(
+              "GEM\n  specs:\n    activesupport (4.2.6)\n      i18n (~> 0.7)"
+            )
+          end
+          let(:current) do
+            ::Bundler::LockfileParser.new(
+              "GEM\n  specs:\n    activesupport (5.1.1)\n      concurrent-ruby (~> 1.0, >= 1.0.2)"
+            )
+          end
+
+          it { expect(bundler.pull_request_body).not_to include expected }
+        end
       end
     end
   end


### PR DESCRIPTION
# Summary

This pull-req's objective is the bug fix.

## Steps to reproduce
### (1) on receiver project
- 1 Add gem activesupport (4.2.6) to Gemfile.
- 2 bundle install

### (2) on sender project
- 1 Configure for tachikoma and tachikoma_ai
- 2 bundle exec rake tachikoma:run_bundler

## The cause
ActiveSupport `4.2.6` has not concurrent-ruby bug ActiveSupport `5.1.1` has `concurrent-ruby`.
So `before` variable will be `nil`.

https://github.com/sinsoku/tachikoma_ai/blob/80ec76e0511d1aafbbfda7f29abc88b187ca1fe2/lib/tachikoma_ai/strategies/bundler.rb#L26

## Solution

If before is `nil`, skip making array.

```ruby
next if before.nil?
```